### PR TITLE
Download test files to run npm test in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,11 @@ jobs:
           jf rt u "npm-install.log" "${{ secrets.NPM_STAGING_ARTIFACTORY }}/logs/build_test/${PROJECT_NAME}-${{ github.event.inputs.release_version  }}/" --url https://${{ secrets.JFROG_HOST_NAME }}/artifactory/ --access-token=${{ secrets.JFROG_PASSWORD }}
          
       - name: Run tests
-        run: npm test 2>&1 | tee npm-test.log
+        # Download test files required for this project
+        run: |
+            curl -LO https://test-files.sheetjs.com/test_files.zip
+            unzip -q test_files.zip
+            npm run tests-only 2>&1 | tee npm-test.log
       
       - name: Upload npm test log to Artifactory
         run: |


### PR DESCRIPTION
Download test files to run npm test based on the approach in https://git.sheetjs.com/sheetjs/sheetjs/src/branch/master/Makefile