### PR TITLE
Add fix for CVE-2023-30533

### DIFF
--- a/bits/02_codepage.js
+++ b/bits/02_codepage.js
@@ -45,6 +45,11 @@ function utf16leread(data/*:string*/)/*:string*/ {
 	for(var i = 0; i < (data.length>>1); ++i) o[i] = String.fromCharCode(data.charCodeAt(2*i) + (data.charCodeAt(2*i+1)<<8));
 	return o.join("");
 }
+function utf16lereadu(data/*:Uint8Array*/)/*:string*/ {
+	var o/*:Array<string>*/ = [];
+	for(var i = 0; i < (data.length>>1); ++i) o[i] = String.fromCharCode(data[2*i] + (data[2*i+1]<<8));
+	return o.join("");
+}
 function utf16beread(data/*:string*/)/*:string*/ {
 	var o/*:Array<string>*/ = [];
 	for(var i = 0; i < (data.length>>1); ++i) o[i] = String.fromCharCode(data.charCodeAt(2*i+1) + (data.charCodeAt(2*i)<<8));

--- a/bits/18_cfb.js
+++ b/bits/18_cfb.js
@@ -73,7 +73,7 @@ function slice_by_16_tables(T) {
 		for(c = 256 + n; c < 4096; c += 256) v = table[c] = (v >>> 8) ^ T[v & 0xFF];
 	}
 	var out = [];
-	for(n = 1; n != 16; ++n) out[n - 1] = typeof Int32Array !== 'undefined' ? table.subarray(n * 256, n * 256 + 256) : table.slice(n * 256, n * 256 + 256);
+	for(n = 1; n != 16; ++n) out[n - 1] = typeof Int32Array !== 'undefined' && typeof table.subarray == "function" ? table.subarray(n * 256, n * 256 + 256) : table.slice(n * 256, n * 256 + 256);
 	return out;
 }
 var TT = slice_by_16_tables(T0);

--- a/bits/56_cmntcommon.js
+++ b/bits/56_cmntcommon.js
@@ -3,6 +3,7 @@ function sheet_insert_comments(sheet, comments/*:Array<RawComment>*/, threaded/*
 	var cell/*:Cell*/;
 	comments.forEach(function(comment) {
 		var r = decode_cell(comment.ref);
+		if(r.r < 0 || r.c < 0) return;
 		if(dense) {
 			if(!sheet[r.r]) sheet[r.r] = [];
 			cell = sheet[r.r][r.c];

--- a/bits/71_wbcommon.js
+++ b/bits/71_wbcommon.js
@@ -113,16 +113,19 @@ function safe1904(wb/*:Workbook*/)/*:string*/ {
 	return parsexmlbool(wb.Workbook.WBProps.date1904) ? "true" : "false";
 }
 
-var badchars = /*#__PURE__*/"][*?\/\\".split("");
+var badchars = /*#__PURE__*/":][*?\/\\".split("");
 function check_ws_name(n/*:string*/, safe/*:?boolean*/)/*:boolean*/ {
-	if(n.length > 31) { if(safe) return false; throw new Error("Sheet names cannot exceed 31 chars"); }
-	var _good = true;
-	badchars.forEach(function(c) {
-		if(n.indexOf(c) == -1) return;
-		if(!safe) throw new Error("Sheet name cannot contain : \\ / ? * [ ]");
-		_good = false;
-	});
-	return _good;
+	try {
+		if(n == "") throw new Error("Sheet name cannot be blank");
+		if(n.length > 31) throw new Error("Sheet name cannot exceed 31 chars");
+		if(n.charCodeAt(0) == 0x27 || n.charCodeAt(n.length - 1) == 0x27) throw new Error("Sheet name cannot start or end with apostrophe (')");
+		if(n.toLowerCase() == "history") throw new Error("Sheet name cannot be 'History'");
+		badchars.forEach(function(c) {
+			if(n.indexOf(c) == -1) return;
+			throw new Error("Sheet name cannot contain : \\ / ? * [ ]");
+		});
+	} catch(e) { if(safe) return false; throw e; }
+	return true;
 }
 function check_wb_names(N, S, codes) {
 	N.forEach(function(n,i) {

--- a/bits/79_html.js
+++ b/bits/79_html.js
@@ -81,7 +81,7 @@ function make_html_row(ws/*:Worksheet*/, r/*:Range*/, R/*:number*/, o/*:Sheet2HT
 			sp["data-t"] = cell && cell.t || 'z';
 			if(cell.v != null) sp["data-v"] = cell.v;
 			if(cell.z != null) sp["data-z"] = cell.z;
-			if(cell.l && (cell.l.Target || "#").charAt(0) != "#") w = '<a href="' + cell.l.Target +'">' + w + '</a>';
+			if(cell.l && (cell.l.Target || "#").charAt(0) != "#") w = '<a href="' + escapehtml(cell.l.Target) +'">' + w + '</a>';
 		}
 		sp.id = (o.id || "sjs") + "-" + coord;
 		oo.push(writextag('td', w, sp));

--- a/bits/87_read.js
+++ b/bits/87_read.js
@@ -50,7 +50,13 @@ function read_plaintext_raw(data/*:RawData*/, o/*:ParseOpts*/)/*:Workbook*/ {
 function read_utf16(data/*:RawData*/, o/*:ParseOpts*/)/*:Workbook*/ {
 	var d = data;
 	if(o.type == 'base64') d = Base64_decode(d);
-	d = $cptable.utils.decode(1200, d.slice(2), 'str');
+	if(typeof ArrayBuffer !== "undefined" && data instanceof ArrayBuffer) d = new Uint8Array(data);
+	d = typeof $cptable !== "undefined" ? $cptable.utils.decode(1200, d.slice(2), 'str') : (
+		(has_buf && Buffer.isBuffer(data)) ? data.slice(2).toString("utf16le") :
+		(typeof Uint8Array !== "undefined" && d instanceof Uint8Array) ? (
+			typeof TextDecoder !== "undefined" ? new TextDecoder("utf-16le").decode(d.slice(2)) : utf16lereadu(d.slice(2))
+		) : utf16leread(d.slice(2))
+	);
 	o.type = "binary";
 	return read_plaintext(d, o);
 }

--- a/test.js
+++ b/test.js
@@ -1769,6 +1769,21 @@ describe('invalid files', function() {
 			wb.SheetNames.push(wb.SheetNames[0]);
 			assert.throws(function() { X.write(wb, {type:'binary'}); });
 		});
+		it('should fail if sheet name is not valid', function() {
+			var names = [
+				"", // cannot be blank
+				"abcdefghijklmnopqrstuvwxyz1234567890", // cannot exceed 31 chars
+				"'sheetjs", "sheetjs'", // cannot start or end with apostrophe
+				"History", // cannot be History
+				"Sheet:JS", "Sheet]JS", "Sheet[JS", "Sheet*JS", // bad characters
+				"Sheet?JS", "Sheet\\JS", "Sheet\/JS"
+			];
+			names.forEach(function(n) { assert.throws(function() {
+				var wb = { SheetNames: [n], Sheets: {} };
+				wb.Sheets[n] = X.utils.aoa_to_sheet([["SheetJS"]]);
+				X.write(wb, {type:"binary", bookType:"xlsx"});
+			}); });
+		});
 	});
 });
 


### PR DESCRIPTION
This PR fixes a high vulnerability (CVE-2023-30533) by blocking prototype pollution attempts while reading other files

### Details

| **Field**              | **Description**                                                                                                                                          |
|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
| **CVE ID**             | CVE-2023-30533                                                                                       |
| **Severity**           | High                                                                                                                                                     |
| **Summary**            | SheetJS Community Edition before 0.19.3 allows Prototype Pollution via a crafted file. |
